### PR TITLE
build: use debian:10 for the base image

### DIFF
--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-ARG GS_MGMT_BUILDER_BASE=ubuntu:20.04
+ARG GS_MGMT_BUILDER_BASE=debian:10
 
 ARG http_proxy
 ARG https_proxy
@@ -60,4 +60,4 @@ RUN --mount=type=bind,source=sm/oopt-tai,target=/root/sm/oopt-tai,rw \
 
 RUN pip install /usr/share/wheels/*.whl
 
-ADD sm/oopt-tai/meta/main.py /usr/local/lib/python3.8/dist-packages/tai.py
+ADD sm/oopt-tai/meta/main.py /usr/local/lib/python3.7/dist-packages/tai.py

--- a/docker/run.Dockerfile
+++ b/docker/run.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
 
 ARG GS_MGMT_BUILDER_IMAGE=gs-mgmt-builder:latest
-ARG GS_MGMT_BASE=ubuntu:20.04
+ARG GS_MGMT_BASE=debian:10
 
 FROM $GS_MGMT_BUILDER_IMAGE as builder
 


### PR DESCRIPTION
Goldstone uses debian:10. By this change, the same deb/wheel packages built
inside the build image can be installed on Goldstone host.

Signed-off-by: Wataru Ishida <wataru.ishid@gmail.com>
